### PR TITLE
feat: use value from input

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -119,17 +119,16 @@ const Editor = ({ readOnly = false }: Props) => {
 
   const getCallValue = useCallback(() => {
     const _callValue = BigInt(callValue)
-    let cv = 0n
-
-    if (unit === ValueUnit.Gwei) {
-      cv = _callValue * BigInt('1000000000')
-    } else if (unit === ValueUnit.Finney) {
-      cv = _callValue * BigInt('1000000000000000')
-    } else if (unit === ValueUnit.Ether) {
-      cv = _callValue * BigInt('1000000000000000000')
+    switch (unit) {
+      case ValueUnit.Gwei:
+        return _callValue * BigInt('1000000000')
+      case ValueUnit.Finney:
+        return _callValue * BigInt('1000000000000000')
+      case ValueUnit.Ether:
+        return _callValue * BigInt('1000000000000000000')
+      default:
+        return _callValue
     }
-
-    return cv
   }, [callValue, unit])
 
   const deployByteCode = useCallback(

--- a/context/cairoContext.tsx
+++ b/context/cairoContext.tsx
@@ -92,8 +92,9 @@ export const CairoProvider = ({ children }: PropsWithChildren<{}>) => {
     data: string,
   ) => {
     contract?.functions['execute'](
-      // TODO: remove hardcoded zero value in execute call context
-      0,
+      // TODO: use toFelt() method from starknet.js once bigint is supported
+      // see https://github.com/0xs34n/starknet.js/pull/399
+      value.toString(),
       hex2bytes(byteCode),
       hex2bytes(data),
     ).then((response) => {
@@ -127,8 +128,9 @@ export const CairoProvider = ({ children }: PropsWithChildren<{}>) => {
     console.log(contract?.address)
     const response = await contract?.functions['execute_at_address'](
       _evmContractAddress,
-      // TODO: remove hardcoded zero value in execute call context
-      0,
+      // TODO: use toFelt() method from starknet.js once bigint is supported
+      // see https://github.com/0xs34n/starknet.js/pull/399
+      value.toString(),
       hex2bytes(callData),
     )
     const trace = await starknetSequencerProvider.getTransactionTrace(

--- a/docs/opcodes/3F.mdx
+++ b/docs/opcodes/3F.mdx
@@ -11,7 +11,7 @@ group: Environmental Information
 
 ## Stack output
 
-0. `hash`: hash of the chosen account's [code](/about), or 0 if the account has no [code](/about).
+0. `hash`: hash of the chosen account's [code](/about), the empty hash (0xc5d24601...) if the account has no [code](/about), or 0 if the account does not exist or has been destroyed.
 
 ## Examples
 

--- a/docs/opcodes/FF/berlin.mdx
+++ b/docs/opcodes/FF/berlin.mdx
@@ -1,6 +1,6 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionally, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
 
 ## Gas refunds
 

--- a/docs/opcodes/FF/london.mdx
+++ b/docs/opcodes/FF/london.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionally, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.


### PR DESCRIPTION
Send value from input() instead of hard-coded 0.

We cannot use starknet.js toFelt() until bigint is supported, see https://github.com/0xs34n/starknet.js/pull/399

There is a bug currently in evm.codes with value when unit is wei(), this has been fixed [there](https://github.com/sayajin-labs/kakarot-playground/pull/10/commits/6c6e7f9b3ac49e03b2409e3f9bbff02c94be2f2a) so this PR contains a merge from evm.codes main